### PR TITLE
Fix pick() in loose mode returning wrong locale

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -54,7 +54,7 @@ class Parser
     public function pick(array $supportedLocales, $strict = true)
     {
         /** @var Component[] $locales */
-        $locales = [];
+        $locales = array();
         foreach ($supportedLocales as $locale) {
             $locales[] = Component::parse($locale);
         }
@@ -92,7 +92,7 @@ class Parser
      */
     private function findClosestMatch(array $components, Component $component, $strict)
     {
-        $results = [];
+        $results = array();
         foreach ($components as $supportedComponent) {
             if ($supportedComponent->isEqualTo($component, $strict)) {
                 $results[] = $supportedComponent;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -106,6 +106,6 @@ class Parser
             }
         }
 
-        return $results[0] ?? null;
+        return isset($results[0]) ? $results[0] : null;
     }
 }

--- a/test/ParserTest.php
+++ b/test/ParserTest.php
@@ -145,11 +145,15 @@ class ParserTest extends TestCase
             array(
                 array('en', 'pl'), true, 'en-US;q=0.6', '',
             ),
+            // loose mode
             array(
-                array('en', 'pl'), false, 'en-US;q=0.6', 'en', // loose mode
+                array('en', 'pl'), false, 'en-US;q=0.6', 'en',
             ),
             array(
-                array('en-US', 'en', 'pl'), false, 'en-US;q=0.6', 'en-US', // loose mode
+                array('en-US', 'en', 'pl'), false, 'en-US;q=0.6', 'en-US',
+            ),
+            array(
+                array('en', 'en-US', 'pl'), false, 'en-US;q=0.6', 'en-US',
             )
         );
     }


### PR DESCRIPTION
The wrong result is returned in the following case when loose mode is used:
```
array('en', 'en-US', 'pl'), false, 'en-US;q=0.6', 'en-US',
```

Previously it would return `en`, when it should have returned `en-US`.